### PR TITLE
Add xml-twig-tools dependency

### DIFF
--- a/docs/openvas/config/ubuntu_21.4.4.sh
+++ b/docs/openvas/config/ubuntu_21.4.4.sh
@@ -40,7 +40,7 @@ graphviz bison postgresql postgresql-contrib postgresql-server-dev-all \
 heimdal-dev xmltoman nmap npm nodejs virtualenv gnupg rsync yarnpkg \
 python3-paramiko python3-lxml python3-defusedxml python3-pip python3-psutil \
 python3-setuptools python3-packaging python3-wrapt python3-cffi python3-redis \
-xmlstarlet texlive-fonts-recommended texlive-latex-extra perl-base
+xmlstarlet texlive-fonts-recommended texlive-latex-extra perl-base xml-twig-tools
 
 # Install yarn
 sudo npm install -g yarn


### PR DESCRIPTION
The gvmd daemon requires `xml_split` command.

Avoid errors like:
```
Jan 12 11:07:47 ov gvmd[42261]: sh: 1: xml_split: not found
```